### PR TITLE
R58 compatibility

### DIFF
--- a/vspreview/core/types.py
+++ b/vspreview/core/types.py
@@ -758,7 +758,6 @@ class Output(YAMLObject):
             'primaries_in_s': self.main.VS_OUTPUT_PRIMARIES,
             'range_in_s'    : self.main.VS_OUTPUT_RANGE,
             'chromaloc_in_s': self.main.VS_OUTPUT_CHROMALOC,
-            'prefer_props'  : self.main.VS_OUTPUT_PREFER_PROPS,
         }
 
         if not alpha and not akarin:

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -345,7 +345,6 @@ class MainWindow(AbstractMainWindow):
     VS_OUTPUT_PRIMARIES       = Output.Primaries.BT709
     VS_OUTPUT_RANGE           = Output.Range.LIMITED
     VS_OUTPUT_CHROMALOC       = Output.ChromaLoc.LEFT
-    VS_OUTPUT_PREFER_PROPS    = True
     VS_OUTPUT_RESIZER_KWARGS  = {  # type: Mapping[str, str]
         'dither_type': 'error_diffusion',
     }


### PR DESCRIPTION
prefer_props is no longer an option: https://github.com/vapoursynth/vapoursynth/commit/9455a1e984ecae26fd9c2204848af214c8238386

I have not tested this with Vapoursynth-Classic.