### PR TITLE
Fix vsp display

### DIFF
--- a/vspreview/core/types.py
+++ b/vspreview/core/types.py
@@ -758,6 +758,7 @@ class Output(YAMLObject):
             'primaries_in_s': self.main.VS_OUTPUT_PRIMARIES,
             'range_in_s'    : self.main.VS_OUTPUT_RANGE,
             'chromaloc_in_s': self.main.VS_OUTPUT_CHROMALOC,
+            'prefer_props'  : self.main.VS_OUTPUT_PREFER_PROPS,
         }
 
         if not alpha and not akarin:

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -345,6 +345,7 @@ class MainWindow(AbstractMainWindow):
     VS_OUTPUT_PRIMARIES       = Output.Primaries.BT709
     VS_OUTPUT_RANGE           = Output.Range.LIMITED
     VS_OUTPUT_CHROMALOC       = Output.ChromaLoc.LEFT
+    VS_OUTPUT_PREFER_PROPS    = True
     VS_OUTPUT_RESIZER_KWARGS  = {  # type: Mapping[str, str]
         'dither_type': 'error_diffusion',
     }


### PR DESCRIPTION
Revert "prefer_props has been removed". This reverts commit 189abb8d605387a5e217ac09ff92400e270f7b54.

vapoursynth-classcic not removed vsresize’s prefer_props, default value is false. But vapoursynth change default value to true, and remove it.

https://github.com/AmusementClub/vapoursynth-classic/blob/cdaa028e62210b2fda2c1599ab7ec4991220729e/src/core/vsresize.cpp#L468=